### PR TITLE
Version v1.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
         easyxcodegenerator.h easyxcodegenerator.cpp
         customlineitem.h customlineitem.cpp
         customrectangleitem.h customrectangleitem.cpp
+        customtextitem.h customtextitem.cpp
 
 
     )

--- a/CMakeLists.txt.user
+++ b/CMakeLists.txt.user
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 13.0.2, 2024-07-06T21:52:28. -->
+<!-- Written by QtCreator 13.0.2, 2024-07-09T20:44:15. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
-  <value type="QByteArray">{098a6ee9-0880-4058-a41d-790f3f083daf}</value>
+  <value type="QByteArray">{de1f5ee8-aef9-4421-8cb4-849594f6a82d}</value>
  </data>
  <data>
   <variable>ProjectExplorer.Project.ActiveTarget</variable>
@@ -76,7 +76,7 @@
     <value type="bool" key="ClangTools.AnalyzeOpenFiles">true</value>
     <value type="bool" key="ClangTools.BuildBeforeAnalysis">true</value>
     <value type="QString" key="ClangTools.DiagnosticConfig">Builtin.DefaultTidyAndClazy</value>
-    <value type="int" key="ClangTools.ParallelJobs">10</value>
+    <value type="int" key="ClangTools.ParallelJobs">8</value>
     <value type="bool" key="ClangTools.PreferConfigFile">true</value>
     <valuelist type="QVariantList" key="ClangTools.SelectedDirs"/>
     <valuelist type="QVariantList" key="ClangTools.SelectedFiles"/>
@@ -109,7 +109,7 @@
 -DCMAKE_CXX_COMPILER:FILEPATH=%{Compiler:Executable:Cxx}
 -DCMAKE_CXX_FLAGS_INIT:STRING=%{Qt:QML_DEBUG_FLAG}</value>
     <value type="int" key="EnableQmlDebugging">0</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">D:\BaiduSyncdisk\QT-project\DifficultX\DifficultX\build\Desktop_Qt_6_7_2_MinGW_64_bit-Debug</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">C:\Users\Alpha.LAPTOP-O2RBBHUH\Documents\AlphaTest\build\Desktop_Qt_6_7_2_MinGW_64_bit-Debug</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="QString" key="CMakeProjectManager.MakeStep.BuildPreset"></value>
@@ -165,7 +165,7 @@
 -DCMAKE_C_COMPILER:FILEPATH=%{Compiler:Executable:C}
 -DCMAKE_CXX_COMPILER:FILEPATH=%{Compiler:Executable:Cxx}
 -DCMAKE_CXX_FLAGS_INIT:STRING=%{Qt:QML_DEBUG_FLAG}</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">D:\BaiduSyncdisk\QT-project\DifficultX\DifficultX\build\Desktop_Qt_6_7_2_MinGW_64_bit-Release</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">C:\Users\Alpha.LAPTOP-O2RBBHUH\Documents\AlphaTest\build\Desktop_Qt_6_7_2_MinGW_64_bit-Release</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="QString" key="CMakeProjectManager.MakeStep.BuildPreset"></value>
@@ -219,7 +219,7 @@
 -DCMAKE_C_COMPILER:FILEPATH=%{Compiler:Executable:C}
 -DCMAKE_CXX_COMPILER:FILEPATH=%{Compiler:Executable:Cxx}
 -DCMAKE_CXX_FLAGS_INIT:STRING=%{Qt:QML_DEBUG_FLAG}</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">D:\BaiduSyncdisk\QT-project\DifficultX\DifficultX\build\Desktop_Qt_6_7_2_MinGW_64_bit-RelWithDebInfo</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">C:\Users\Alpha.LAPTOP-O2RBBHUH\Documents\AlphaTest\build\Desktop_Qt_6_7_2_MinGW_64_bit-RelWithDebInfo</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="QString" key="CMakeProjectManager.MakeStep.BuildPreset"></value>
@@ -274,7 +274,7 @@
 -DCMAKE_CXX_COMPILER:FILEPATH=%{Compiler:Executable:Cxx}
 -DCMAKE_CXX_FLAGS_INIT:STRING=%{Qt:QML_DEBUG_FLAG}</value>
     <value type="int" key="EnableQmlDebugging">0</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">D:\BaiduSyncdisk\QT-project\DifficultX\DifficultX\build\Desktop_Qt_6_7_2_MinGW_64_bit-Profile</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">C:\Users\Alpha.LAPTOP-O2RBBHUH\Documents\AlphaTest\build\Desktop_Qt_6_7_2_MinGW_64_bit-Profile</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="QString" key="CMakeProjectManager.MakeStep.BuildPreset"></value>
@@ -328,7 +328,7 @@
 -DCMAKE_C_COMPILER:FILEPATH=%{Compiler:Executable:C}
 -DCMAKE_CXX_COMPILER:FILEPATH=%{Compiler:Executable:Cxx}
 -DCMAKE_CXX_FLAGS_INIT:STRING=%{Qt:QML_DEBUG_FLAG}</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">D:\BaiduSyncdisk\QT-project\DifficultX\DifficultX\build\Desktop_Qt_6_7_2_MinGW_64_bit-MinSizeRel</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">C:\Users\Alpha.LAPTOP-O2RBBHUH\Documents\AlphaTest\build\Desktop_Qt_6_7_2_MinGW_64_bit-MinSizeRel</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="QString" key="CMakeProjectManager.MakeStep.BuildPreset"></value>
@@ -400,7 +400,7 @@
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
     <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">D:/BaiduSyncdisk/QT-project/DifficultX/DifficultX/build/Desktop_Qt_6_7_2_MinGW_64_bit-Debug</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">C:/Users/Alpha.LAPTOP-O2RBBHUH/Documents/AlphaTest/build/Desktop_Qt_6_7_2_MinGW_64_bit-Debug</value>
    </valuemap>
    <value type="qlonglong" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
   </valuemap>

--- a/colorpickerwidget.cpp
+++ b/colorpickerwidget.cpp
@@ -11,15 +11,23 @@ ColorPickerWidget::ColorPickerWidget(QWidget *parent) : QWidget(parent) {
     connect(setlinecolor, &QPushButton::clicked, this, &ColorPickerWidget::SetLineColor);
     QPushButton *setfillcolor = new QPushButton("设置为填充颜色", this);
     connect(setfillcolor, &QPushButton::clicked, this, &ColorPickerWidget::SetFillColor);
+    QPushButton *settextcolor = new QPushButton("设置为字体颜色", this);
+    connect(settextcolor, &QPushButton::clicked, this, &ColorPickerWidget::SetTextColor);
     QWidget *SetColor = new QWidget(this);
     QHBoxLayout *ButtonSet = new QHBoxLayout(SetColor);
     ButtonSet->addWidget(setbkcolor, 1);
     ButtonSet->addWidget(setlinecolor, 1);
     ButtonSet->addWidget(setfillcolor, 1);
+    ButtonSet->addWidget(settextcolor, 1);
 
     QPushButton *getbkcolor = new QPushButton("获取背景颜色", this);
+    connect(getbkcolor, &QPushButton::clicked, this, &ColorPickerWidget::getBackColor);
     QPushButton *getlinecolor = new QPushButton("获取线条颜色", this);
+    connect(getlinecolor, &QPushButton::clicked, this, &ColorPickerWidget::getLineColor);
     QPushButton *getfillcolor = new QPushButton("获取填充颜色", this);
+    connect(getfillcolor, &QPushButton::clicked, this, &ColorPickerWidget::getFillColor);
+    QPushButton *gettextcolor = new QPushButton("获取字体颜色", this);
+    connect(gettextcolor, &QPushButton::clicked, this, &ColorPickerWidget::getTextColor);
     QPushButton *confirm = new QPushButton("确定", this);
     connect(confirm, &QPushButton::clicked, this, &ColorPickerWidget::onSendColorData);
     QWidget *GetColor = new QWidget(this);
@@ -27,8 +35,7 @@ ColorPickerWidget::ColorPickerWidget(QWidget *parent) : QWidget(parent) {
     ButtonGet->addWidget(getbkcolor, 1);
     ButtonGet->addWidget(getlinecolor, 1);
     ButtonGet->addWidget(getfillcolor, 1);
-
-
+    ButtonGet->addWidget(gettextcolor, 1);
 
     layout->addWidget(button);
     layout->addWidget(GetColor);
@@ -82,4 +89,24 @@ void ColorPickerWidget::SetFillColor(){
 }
 void ColorPickerWidget::SetBackColor(){
     BackColor = CurrentColor;
+}
+void ColorPickerWidget::SetTextColor(){
+    TextColor = CurrentColor;
+}
+
+void ColorPickerWidget::getLineColor(){
+    CurrentColor = LineColor;
+    colorLabel->setText(CurrentColor);
+}
+void ColorPickerWidget::getFillColor(){
+    CurrentColor = FillColor;
+    colorLabel->setText(CurrentColor);
+}
+void ColorPickerWidget::getBackColor(){
+    CurrentColor = BackColor;
+    colorLabel->setText(CurrentColor);
+}
+void ColorPickerWidget::getTextColor(){
+    CurrentColor = TextColor;
+    colorLabel->setText(CurrentColor);
 }

--- a/colorpickerwidget.h
+++ b/colorpickerwidget.h
@@ -8,6 +8,10 @@ class ColorPickerWidget : public QWidget {
 
 public:
     ColorPickerWidget(QWidget *parent = nullptr);
+    QString LineColor;
+    QString FillColor;
+    QString BackColor;
+    QString TextColor;
 
 signals:
     void sendColorData(const QString &data);
@@ -20,10 +24,13 @@ private:
     void SetLineColor();
     void SetFillColor();
     void SetBackColor();
+    void SetTextColor();
+    void getLineColor();
+    void getFillColor();
+    void getBackColor();
+    void getTextColor();
     QLabel *colorLabel;
-    QString LineColor;
-    QString FillColor;
-    QString BackColor;
+
     QString CurrentColor;
 };
 #endif // COLORPICKERWIDGET_H

--- a/communal.h
+++ b/communal.h
@@ -28,6 +28,8 @@
 #include <QGraphicsLineItem>
 #include <QInputDialog>
 #include <QPen>
+#include <QComboBox>
+#include <QSlider>
 #include <QBrush>
 #include <QGraphicsScene>
 #include <QGraphicsView>

--- a/customcircleitem.h
+++ b/customcircleitem.h
@@ -12,7 +12,6 @@ class CustomCircleItem : public QGraphicsEllipseItem {
     //Q_OBJECT
 public:
     CustomCircleItem(qreal x, qreal y, qreal diameter, QGraphicsItem *parent = nullptr);
-    //void changeByLineedit(QPointF c,double r);
     void changeByLineedit(double cx,double cy,double r);
 
 protected:

--- a/customgraphicssene.h
+++ b/customgraphicssene.h
@@ -4,7 +4,9 @@
 #include "communal.h"
 #include "customcircleitem.h"
 #include "customlineitem.h"
-#include"customrectangleitem.h"
+#include "customrectangleitem.h"
+#include "customtextitem.h"
+#include "customrectangleitem.h"
 
 QT_BEGIN_NAMESPACE
 class QGraphicsEllipseItem;
@@ -24,9 +26,17 @@ public:
     void updateData();
     CustomCircleItem *circle;
     CustomLineItem *line;
+    CustomTextItem *text;
+    bool usingFill;
 
     QPen LineColor;
+    QPen BackColor;
+    QPen TextColor;
+    QBrush FillColor;
     void DrawCircle(double x, double y, double Radius);
+    void DrawLine(double x1, double y1, double x2, double y2);
+    void DrawRect(double x1, double y1, double x2, double y2);
+    void DrawText(double x, double y, QString text);
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
@@ -34,7 +44,7 @@ protected:
 
 
 private:
-
+    void valueClear();
     QGraphicsEllipseItem *centerPoint;
     QGraphicsEllipseItem *edgePoint;
     QGraphicsLineItem *tempLine;
@@ -43,6 +53,7 @@ private:
     bool isAddingText;
     bool isAddingLine;
     bool isAddingRectangle;
+
 
     QPointF firstPoint;
     double Radius;
@@ -53,7 +64,7 @@ signals:
     void textAdded(const QString &text, const QPointF &pos);
     void drawingCircleFinished(const QString &msg);
     void drawingLineFinished(const QString &msg);
-
+    void drawingRectFinished(const QString &msg);
 public slots:
     void ReceivePara1ValueChanged(double value);
     void ReceivePara2ValueChanged(double value);

--- a/customlineitem.cpp
+++ b/customlineitem.cpp
@@ -3,7 +3,7 @@
 #include <QBrush>
 
 CustomLineItem::CustomLineItem(const QLineF &line, QGraphicsItem *parent)
-    : QGraphicsLineItem(line, parent), dragState(NoDrag)
+    : QGraphicsLineItem(line, parent), dragState(NoDrag),R(0),B(0),G(0)
 {
     setFlag(QGraphicsItem::ItemIsMovable, true);
     setFlag(QGraphicsItem::ItemIsSelectable, true);

--- a/customlineitem.h
+++ b/customlineitem.h
@@ -31,6 +31,9 @@ public:
     QPointF lastMousePos;
     QPointF point1;
     QPointF point2;//获取point1和point2
+    int R;
+    int G;
+    int B;
     // QGraphicsEllipseItem *startPoint;
     // QGraphicsEllipseItem *endPoint;
     void updateEndpoints();

--- a/customrectangleitem.cpp
+++ b/customrectangleitem.cpp
@@ -95,3 +95,16 @@ void CustomRectangleItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
     isDraggingRect=false;
     QGraphicsRectItem::mouseReleaseEvent(event); // 调用基类的鼠标释放事件处理函数
 }
+
+void CustomRectangleItem::changeByLineedit(double x1,double y1,double x2,double y2)
+{
+    if (!isSelected()) {  // 如果未选中
+        return;
+    }
+    QPointF p1=QPointF{x1,y1};
+    QPointF p2=QPointF{x2,y2};
+    LT=p1;
+    RB=p2;
+    setRect(QRectF(mapFromScene(LT),mapFromScene(RB)));  // 更新圆形项的位置和大小
+    update();
+}

--- a/customrectangleitem.h
+++ b/customrectangleitem.h
@@ -8,15 +8,19 @@
 #include <QGraphicsItemGroup>
 #include <QGraphicsScene>
 #include <QGraphicsSceneMouseEvent>
+#include <QRectF>
+#include "communal.h"
 
 class CustomRectangleItem : public QGraphicsRectItem {
 public:
     CustomRectangleItem(const QRectF &rect, QGraphicsItem *parent = nullptr);
+    void changeByLineedit(double x1,double y1,double x2,double y2);
 
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
+
 
 private:
     QGraphicsEllipseItem *topLeftHandle;

--- a/customtextitem.cpp
+++ b/customtextitem.cpp
@@ -1,0 +1,80 @@
+// 包含CustomTextItem.h头文件
+#include "CustomTextItem.h"
+
+// CustomTextItem类的构造函数
+// 参数：text - 要显示的文本内容
+// 参数：parent - 父级QGraphicsItem对象
+CustomTextItem::CustomTextItem(const QString &text, QGraphicsItem *parent)
+    : QGraphicsTextItem(text, parent), // 调用基类的构造函数，初始化文本项
+    isMovable(false) // 设置isMovable标志为false，表示文本项不可移动
+{
+    setFlag(QGraphicsItem::ItemIsSelectable, true); // 设置文本项可以选择
+    setFlag(QGraphicsItem::ItemIsFocusable, true); // 设置文本项可以获取焦点
+}
+
+// 设置字体大小和样式
+// 参数：font - 要设置的QFont对象
+void CustomTextItem::setFont(const QFont &font)
+{
+    textstyle=font.family();
+    textsize=-font.pixelSize();
+    QRectF boundingRect = this->boundingRect();
+    textRectWidth=boundingRect.x();
+    textRectHight=boundingRect.y();
+    qDebug()<<textstyle;
+    QGraphicsTextItem::setFont(font); // 调用基类的方法设置字体
+}
+
+// 设置文本内容
+// 参数：text - 要设置的文本字符串
+void CustomTextItem::setText(const QString &text) {
+    QGraphicsTextItem::setPlainText(text); // 调用基类的方法设置文本
+}
+
+// 设置文本项是否可移动
+// 参数：movable - 控制文本项是否可移动的布尔值
+void CustomTextItem::setMovable(bool movable) {
+    isMovable = movable; // 更新isMovable标志
+    setFlag(QGraphicsItem::ItemIsMovable, movable); // 根据movable的值设置是否可移动的标志
+}
+
+// 鼠标按下事件处理函数
+// 参数：event - QGraphicsSceneMouseEvent对象，包含鼠标事件信息
+void CustomTextItem::mousePressEvent(QGraphicsSceneMouseEvent *event) {
+    if(isSelected())
+    {
+        isMovable=true;
+    }
+    QGraphicsTextItem::mousePressEvent(event); // 调用基类的方法处理鼠标按下事件
+}
+
+// 鼠标移动事件处理函数
+void CustomTextItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
+    // if (isMovable)
+    // { // 只有当文本项可移动时，才处理移动
+    //     QPointF newPoint=event->scenePos();
+    //     position=newPoint;
+    //     setPos(position);
+    // }
+    position=this->scenePos();
+    QGraphicsTextItem::mouseMoveEvent(event); // 调用基类的方法处理鼠标移动事件
+}
+
+// 鼠标释放事件处理函数
+// 参数：event - QGraphicsSceneMouseEvent对象，包含鼠标事件信息
+void CustomTextItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
+    isMovable=false;
+    qDebug()<<position;
+    QGraphicsTextItem::mouseReleaseEvent(event); // 调用基类的方法处理鼠标释放事件
+}
+
+void CustomTextItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)//双击事件处理函数
+{
+    bool ok;
+    QString currentText = toPlainText();
+    QString text = QInputDialog::getText(nullptr, "编辑文字", "请输入新文字:", QLineEdit::Normal, currentText, &ok);
+    if (ok && !text.isEmpty()) {
+        setText(text);
+    }
+    QGraphicsTextItem::mouseDoubleClickEvent(event);
+}

--- a/customtextitem.h
+++ b/customtextitem.h
@@ -1,0 +1,33 @@
+#ifndef CUSTOMTEXTITEM_H
+#define CUSTOMTEXTITEM_H
+
+#include <QGraphicsTextItem>
+#include <QFont>
+#include<QInputDialog>
+#include <QGraphicsSceneMouseEvent>
+
+class CustomTextItem : public QGraphicsTextItem {
+public:
+    CustomTextItem(const QString &text, QGraphicsItem *parent = nullptr);
+
+    void setFont(const QFont &font);
+    void setText(const QString &text);
+    void setMovable(bool movable);
+
+protected:
+    void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+    void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
+    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
+
+public:
+    bool isMovable;
+    QString textstyle;//没初始化
+    int textsize;
+    int textRectWidth;
+    int textRectHight;
+    QPointF position;//左上位置
+    // QString text;
+};
+
+#endif // CUSTOMTEXTITEM_H

--- a/easyxcodegenerator.cpp
+++ b/easyxcodegenerator.cpp
@@ -10,6 +10,7 @@ vector<CircleItem>circles_gen;//储存圆信息
 vector<LineItem>lines_gen;//储存直线信息
 vector<Operation> HandleList;
 
+
 Operation::Operation(){
     type = "null";
     ptr = nullptr;
@@ -56,15 +57,30 @@ void EasyXCodeGenerator::addLine(QPointF p1,QPointF p2)//增加一个线段
 void EasyXCodeGenerator::generateCode( const CustomGraphicsScene *scene)
 {//点击genecode后遍历scene的所有item并添加到code在点击genecode后才能正常获取code
 
-    int ini_R=0;
-    int ini_G=0;
-    int ini_B=0;
+    QColor iniColor;
+    QColor initextColor;//第一次调用时初始化
+    QColor iniFillcolor;
 
-    code.clear();
+    QFont initial_font;
+    initial_font.setFamily("000");
+    initial_font.setPixelSize(-100);
+
+    bool hasTextsyleChanged=false;
+
+    bool hasFrame;
+    bool hasFilling;
+
+    code.clear();//清空缓存
 
     //预设信息
-    code+="setBKcolor(WIGHT);\n";
-    code+="setcolor(BLACK);\n";
+    code+="\tinitgraph(640, 480);\n";
+    code+="\tsetbkcolor(RGB(255,255,255));\n";
+    code+="\tsetcolor(RGB(0,0,0));\n";
+    code+="\tcleardevice();\n";
+    code+="\tLOGFONT f;\n";
+    code+="\tgettextstyle(&f);\n";
+
+
     vector<QGraphicsItem *>Item;
     vector<QString>tempcode;
     vector<QString>colorcode;
@@ -78,56 +94,206 @@ void EasyXCodeGenerator::generateCode( const CustomGraphicsScene *scene)
 
     for (int i=Item.size()-1;i>=0;i--)
     {
-        qDebug()<<"kaishi"<<endl;
         QGraphicsItem *item=Item[i];
         if (CustomCircleItem *circle = dynamic_cast<CustomCircleItem*>(item))
         {
-            qDebug()<<circle->R<<circle->G<<circle->B<<endl;
-            if(circle->R!=ini_R||circle->G!=ini_G||circle->B!=ini_B)
+            QBrush brush = circle->brush();
+            QPen pen=circle->pen();
+            if (pen.style()!=Qt::NoPen)
             {
-                code+=QString("setcolor(RGB(%1,%2,%3));\n").arg(circle->R).arg(circle->G).arg(circle->B);
-                // colorcode.push_back(QString("setcolor(RGB(%1,%2,%3));\n").arg(circle->R).arg(circle->G).arg(circle->B));//如果有颜色，改画笔
-                ini_R=circle->R;
-                ini_G=circle->G;
-                ini_B=circle->B;
+                QColor currentColor=circle->pen().color();
+                // 无填充
+
+                //qDebug()<<circle->R<<circle->G<<circle->B<<endl;
+                if(currentColor!=iniColor)
+                {
+                    code+=QString("\tsetlinecolor(RGB(%1,%2,%3));\n").arg(circle->R).arg(circle->G).arg(circle->B);
+                    colorcode.push_back(QString("\tsetlinecolor(RGB(%1,%2,%3));\n")
+                                            .arg(circle->R).arg(circle->G).arg(circle->B));//如果有颜色，改画笔
+
+                    iniColor=currentColor;
+                }
+                //tempcode.push_back( QString("circle(%1,%2,%3);\n").arg(circle->center.x()).arg(circle->center.x()).arg(circle->radius));
+
+                hasFrame=true;
             }
-            tempcode.push_back( QString("circle(%1,%2,%3);\n").arg(circle->center.x()).arg(circle->center.x()).arg(circle->radius));
-            code+=QString("circle(%1,%2,%3);\n").arg(circle->center.x()).arg(circle->center.x()).arg(circle->radius);
+            if (brush.style() != Qt::NoBrush) {
+                // 有填充，获取填充颜色
+                QColor currentFillColor = brush.color();
+
+                // 检查颜色是否有变化
+                if (iniFillcolor.isValid() && currentFillColor != iniFillcolor) {
+                    // 如果填充颜色与iniFillColor不同，更新code
+                    code += QString("\tsetfillcolor(RGB(%1,%2,%3);\n")
+                                .arg(currentFillColor.red())
+                                .arg(currentFillColor.green())
+                                .arg(currentFillColor.blue());
+                } else if (!iniFillcolor.isValid()) {
+                    // 如果这是第一次发现有填充颜色的圆，初始化iniFillColor
+                    iniFillcolor = currentFillColor;
+                    // 添加初始化代码到code字符串
+                    code += QString("\tsetfillcolor(RGB(%1,%2,%3);\n")
+                                .arg(currentFillColor.red())
+                                .arg(currentFillColor.green())
+                                .arg(currentFillColor.blue());
+                }
+                hasFilling=true;
+
+            }
+            if(hasFilling&&hasFrame)
+            {
+                code+=QString("\tfillcircle(%1,%2,%3);\n")
+                            .arg(circle->center.x())
+                            .arg(circle->center.y())
+                            .arg(circle->radius);
+                hasFilling=false;
+                hasFrame=false;
+            }
+            else if(hasFilling)
+            {
+                code+=QString("\tsolidcircle(%1,%2,%3);\n")
+                            .arg(circle->center.x())
+                            .arg(circle->center.y())
+                            .arg(circle->radius);
+                hasFilling=false;
+            }
+            else if(hasFrame)
+            {
+                code+=QString("\tcircle(%1,%2,%3);\n")
+                            .arg(circle->center.x())
+                            .arg(circle->center.x())
+                            .arg(circle->radius);
+                hasFrame=false;
+            }
+
+
         }
         else if (CustomLineItem *line = dynamic_cast<CustomLineItem*>(item))
         {
-            // if(line->R!=ini_R||line->G!=ini_G||line->B!=ini_B)
-            // {
-            //     code+=QString("setcolor(RGB(%1,%2,%3));\n").arg(circle->R).arg(circle->G).arg(circle->B);//如果有颜色，改画笔
-            // ini_R=line->R;
-            // ini_G=line->G;
-            // ini_B=line->B;
-            // }
-            code+= QString("line(%1,%2,%3,%4);\n").arg(line->point1.x()).arg(line->point1.y()).arg(line->point2.x()).arg(line->point2.y());
+            //qDebug()<<line->R<<"sdinjfni";
+            QColor currentColor;
+
+            if(iniColor!=currentColor)
+            {
+                //qDebug()<<"222"<<line->G;
+                code+=QString("\tsetlinecolor(RGB(%1,%2,%3));\n").arg(line->R).arg(line->G).arg(line->B);//如果有颜色，改画笔
+                iniColor=currentColor;
+            }
+            code+= QString("\tline(%1,%2,%3,%4);\n").arg(line->point1.x()).arg(line->point1.y()).arg(line->point2.x()).arg(line->point2.y());
+            // qDebug()<< QString("line(%1,%2,%3,%4);\n").arg(line->point1.x()).arg(line->point1.y()).arg(line->point2.x()).arg(line->point2.y());
+        }
+        else if(CustomRectangleItem *rec=dynamic_cast<CustomRectangleItem*>(item))
+        {
+            QBrush brush = rec->brush();
+
+            if (brush.style() == Qt::NoBrush)
+            {
+                QColor currentColor=rec->pen().color();
+                // 无填充
+                if(currentColor!=iniColor)
+                {
+                    qDebug()<<iniColor<<currentColor;
+                    code += QString("\tsetlinecolor(RGB(%1,%2,%3));\n")
+                                .arg(currentColor.red())
+                                .arg(currentColor.green())
+                                .arg(currentColor.blue());
+                    iniColor=currentColor;
+                }
+                hasFrame=true;
+            }
+            else
+            {
+                // 有填充，获取填充颜色
+                QColor currentFillColor = brush.color();
+
+                // 检查颜色是否有变化
+                if (iniFillcolor.isValid() && currentFillColor != iniFillcolor)
+                {
+                    // 如果填充颜色与iniFillColor不同，更新code
+                    code += QString("\tsetfillcolor(RGB(%1,%2,%3));\n")
+                                .arg(currentFillColor.red()).arg(currentFillColor.green()).arg(currentFillColor.blue());
+                    iniFillcolor = currentFillColor; // 更新初始填充颜色
+                }
+                else if (!iniFillcolor.isValid())
+                {
+                    // 如果这是第一次发现有填充颜色的矩形，初始化iniFillColor
+                    iniFillcolor = currentFillColor;
+                    // 添加初始化代码到code字符串
+                    code += QString("\tsetfillcolor(RGB(%1,%2,%3));\n")
+                                .arg(currentFillColor.red()).arg(currentFillColor.green()).arg(currentFillColor.blue());
+                }
+                hasFilling=true;
+
+            }
+            if(hasFilling&&hasFrame)
+            {
+                code+=QString("\tfillcircle(%1,%2,%3);\n")
+                            .arg(circle->center.x())
+                            .arg(circle->center.y())
+                            .arg(circle->radius);
+                hasFilling=false;
+                hasFrame=false;
+            }
+            else if(hasFilling)
+            {
+                code+=QString("\tsolidcircle(%1,%2,%3);\n")
+                            .arg(circle->center.x())
+                            .arg(circle->center.y())
+                            .arg(circle->radius);
+                hasFilling=false;
+            }
+            else if(hasFrame)
+            {
+                code+=QString("\tcircle(%1,%2,%3);\n")
+                            .arg(circle->center.x())
+                            .arg(circle->center.x())
+                            .arg(circle->radius);
+                hasFrame=false;
+            }
+        }
+        else if(CustomTextItem *text=dynamic_cast<CustomTextItem*>(item))
+        {
+            if(text->font().family()!=initial_font.family())
+            {
+                code+=QString("\t_tcscpy_s(f.lfFaceName, _T(\"%1\"));\n").arg(text->font().family());
+                initial_font.setFamily(text->font().family());
+                hasTextsyleChanged=true;
+            }
+            if(text->font().pixelSize()!=initial_font.pixelSize())
+            {
+                code+=QString("\tf.lfHeight = %1;\n").arg(-text->font().pixelSize());
+                hasTextsyleChanged=true;
+            }
+
+            if(hasTextsyleChanged)
+            {
+                code+="\tsettextstyle(&f);\n";
+                hasTextsyleChanged=false;//重置更改布尔值
+            }
+
+            if(!(initextColor.isValid()))
+            {
+                initextColor=text->defaultTextColor();//初始化，颜色没有初始化是无效值
+                code+=QString("\tsettextcolor(RGB(%1,%2,%3));\n")
+                            .arg(text->defaultTextColor().red()).arg(text->defaultTextColor().green()).arg(text->defaultTextColor().blue());
+            }
+            else if(initextColor!=text->defaultTextColor())
+            {
+                initextColor=text->defaultTextColor();//重置当前颜色
+                code+=QString("\tsettextcolor(RGB(%1,%2,%3));\n")
+                            .arg(text->defaultTextColor().red()).arg(text->defaultTextColor().green()).arg(text->defaultTextColor().blue());
+            }
+
+            code+=QString("\touttextxy(%1, %2, _T(\"%3\"));\n").arg(text->position.x()).arg(text->position.y()).arg(text->toPlainText());
+
         }
     }
     qDebug()<<code;
-    // std::vector<std::pair<QPointF, qreal>> circles = scene->getCircles();
-    // for (const auto &circle : circles)
-    // {
-    //     addCircle(circle.first, circle.second); // 使用圆心坐标和半径生成代码
-    // }
-    // // for (const CircleItem &circle : circles) {
-    // //     code+=QString("circle(%1,%2,%3);\n").arg(circle.center.x()).arg(circle.center.y() - 6).arg(circle.radius);
-    // //      // 将圆的信息写入qstring
-    // // }
-    // QFile file(filename);
-    // if (file.open(QIODevice::WriteOnly | QIODevice::Text))
-    // {
-    //     QTextStream out(&file);
 
-    //     test_is_code_right_generator << "code is: " << code << Qt::endl; // 将字符串输出到标准输出
-    //     out << code;
-    //     file.close();
-    // }
 }
 
 QString EasyXCodeGenerator::getCode() const
 {
+    qDebug()<<"gened code: "<<code<<endl;
     return code;
 }

--- a/easyxcodegenerator.h
+++ b/easyxcodegenerator.h
@@ -6,8 +6,9 @@
 #include <vector>
 #include <QTextStream>
 #include "communal.h"
-#include "customgraphicssene.h""
+#include "customgraphicssene.h"
 #include "customcircleitem.h"
+
 
 using std::vector;
 

--- a/imageEditor.cpp
+++ b/imageEditor.cpp
@@ -13,6 +13,11 @@ void ImageEditor::openColorPickerWidget(){
     // 获取A窗口的位置并设置给B窗口
     colorPicker->move(this->pos());
     connect(colorPicker, &ColorPickerWidget::sendColorData, this, &ImageEditor::receiveColorData);
+    colorPicker->LineColor = QString("RGB(%1, %2, %3)").arg(drawingArea->scene->LineColor.color().red()).arg(drawingArea->scene->LineColor.color().green()).arg(drawingArea->scene->LineColor.color().blue());
+    qDebug() << "[DEBUG] The colorPicker's LineColor has been set to " << colorPicker->LineColor;
+    colorPicker->BackColor = QString("RGB(%1, %2, %3)").arg(drawingArea->scene->BackColor.color().red()).arg(drawingArea->scene->BackColor.color().green()).arg(drawingArea->scene->BackColor.color().blue());
+    colorPicker->FillColor = QString("RGB(%1, %2, %3)").arg(drawingArea->scene->FillColor.color().red()).arg(drawingArea->scene->FillColor.color().green()).arg(drawingArea->scene->FillColor.color().blue());
+        //QString("RGB(%1, %2, %3)").arg(color.red()).arg(color.green()).arg(color.blue());
     colorPicker->show();
 }
 
@@ -62,20 +67,65 @@ void ImageEditor::handleDrawingLineFinished(const QString& message) {
     //qDebug() << "[INFO] ImageEditor has received the msg " << x << "," << y << "," << Radius;
 }
 
+void ImageEditor::handleDrawingRectFinished(const QString& message) {
+    QStringList dataList = message.split(',');
+
+    double x1, y1, x2, y2;
+
+    if (dataList.size() == 4) {
+        bool ok1, ok2, ok3, ok4;
+        x1 = dataList[0].toDouble(&ok1);
+        y1 = dataList[1].toDouble(&ok2);
+        x2 = dataList[2].toDouble(&ok3);
+        y2 = dataList[3].toDouble(&ok4);
+    } else {
+        qDebug() << "Incorrect format.";
+    }
+
+    lineEdit_1->setText(QString::number(x1));
+    lineEdit_2->setText(QString::number(y1));
+    lineEdit_3->setText(QString::number(x2));
+    lineEdit_4->setText(QString::number(y2));
+}
+
 void ImageEditor::updateLineEdit(const QString& message) {
     //qDebug() << "[INFO] ImageEditor has received the msg " << message;
 }
 
 void ImageEditor::onAddCircleButtonClicked() {
     //qDebug() << "[INFO] Adding circle";
-    isAddingCircle = !isAddingCircle;  // 切换添加圆形状态
+    isAddingCircle = true;  // 切换添加圆形状态
     isAddingText = false;  // 确保添加文本状态为false
     isAddingRectangle=false;
     isAddingLine = false;
     isAddingRectangle=false;
     drawingArea->scene->setAddingCircle(isAddingCircle);  // 通知场景更新添加圆形状态
-    drawingArea->scene->setAddingText(false);  // 确保场景的添加文本状态为false
+    //drawingArea->scene->setAddingText(false);  // 确保场景的添加文本状态为false
     //qDebug() << "[INFO] Success";
+}
+
+void ImageEditor::onAddFillCircleButtonClicked() {
+    isAddingCircle = true;  // 切换添加圆形状态
+    isAddingText = false;  // 确保添加文本状态为false
+    isAddingRectangle=false;
+    isAddingLine = false;
+    isAddingRectangle=false;
+    drawingArea->scene->usingFill = true;
+    drawingArea->scene->FillColor.setColor(FillCOLOR);
+    qDebug() << "[INFO] ImageEditor send color" << drawingArea->scene->FillColor.color();
+    drawingArea->scene->setAddingCircle(isAddingCircle);  // 通知场景更新添加圆形状态
+    //drawingArea->scene->setAddingText(false);  // 确保场景的添加文本状态为false
+}
+
+void ImageEditor::onAddFillRectangleButtonClicked() {
+    isAddingCircle = false; // 切换添加圆形状态
+    isAddingText = false;  // 确保添加文本状态为false
+    isAddingRectangle=true;
+    isAddingLine = false;
+    drawingArea->scene->usingFill = true;
+    drawingArea->scene->FillColor.setColor(FillCOLOR);
+    qDebug() << "[INFO] ImageEditor send color" << drawingArea->scene->FillColor.color();
+    drawingArea->scene->setAddingRectangle(isAddingRectangle);  // 通知场景更新添加圆形状态
 }
 
 void ImageEditor::onAddLineButtonClicked()
@@ -85,6 +135,17 @@ void ImageEditor::onAddLineButtonClicked()
     isAddingText = false;  // 确保不在添加文字状态
     isAddingRectangle=false;
     drawingArea->scene->setAddingLine(isAddingLine);  // 通知场景开始/停止添加直线
+}
+
+//文字按钮响应函数
+void ImageEditor::onAddTextButtonClicked()
+{
+    isAddingText=!isAddingText;
+    isAddingRectangle=false;//切换添加矩形状态
+    isAddingLine = false;  // 确保不在添加直线的状态
+    isAddingCircle = false;  // 确保不在添加圆状态
+    //
+    drawingArea->scene->setAddingText(isAddingText);  // 通知场景开始/停止添加矩形
 }
 
 //矩形按钮响应函数
@@ -114,6 +175,11 @@ void ImageEditor::handleCircleAdded(QPointF center,qreal r) {
 
 // 逆天 Layout 毁灭吧
 ImageEditor::ImageEditor(QWidget *parent) : QWidget(parent) {
+    isAddingLine = false;
+    isAddingCircle = false;
+    isAddingText = false;
+    isAddingRectangle = false;
+    usingFill = false;
     setWindowTitle("图形编辑器");
 
     QHBoxLayout *mainLayout = new QHBoxLayout(this);
@@ -122,105 +188,128 @@ ImageEditor::ImageEditor(QWidget *parent) : QWidget(parent) {
     QWidget *EditorSet = new QWidget(this);
     QVBoxLayout *layout = new QVBoxLayout(EditorSet);
     // 设置子窗口的布局和控件
-    //QVBoxLayout *layout = new QVBoxLayout(this);
-    //QLabel *label = new QLabel("这是一个嵌入的子窗口", this);
 
     drawingArea = new CustomDrawingArea(LineColor, this);
     drawingArea->scene->setSceneRect(0, 0, 640, 480);
-    qDebug() << "[INFO] DrawingArea: Set Pen to " << LineColor;
+    //qDebug() << "[INFO] DrawingArea: Set Pen to " << LineColor;
 
 
     connect(drawingArea, &DrawingArea::shapeSelected, this, &ImageEditor::onShapeSelected);
     connect(drawingArea->scene, &CustomGraphicsScene::drawingCircleFinished, this, &ImageEditor::handleDrawingCircleFinished);
     connect(drawingArea->scene, &CustomGraphicsScene::drawingLineFinished, this, &ImageEditor::handleDrawingLineFinished);
+    connect(drawingArea->scene, &CustomGraphicsScene::drawingRectFinished, this, &ImageEditor::handleDrawingRectFinished);
 
-
-    //connect(drawingArea->scene->circle, &CustomCircleItem::drawingFinished, this, &ImageEditor::handleDrawingFinished);
-    //connect(drawingArea->scene->circle, &CustomGraphicsScene::drawingFinished, this, &ImageEditor::handleDrawingFinished);
-    //connect(drawingArea->scene, &DrawingArea::drawingFinished, this, &ImageEditor::updateLineEdit);
     mainLayout->addWidget(drawingArea, 4);
     //setCentralWidget(view);  // 设置中心部件为图形视图
 
-    QLabel *parameterTitle = new QLabel("参数区", this);
-    parameterTitle->setAlignment(Qt::AlignCenter);
-    layout->addWidget(parameterTitle, 4);
+    QWidget *parameterArea = new QWidget(this);
+    QVBoxLayout *parameterAreaLayout = new QVBoxLayout(parameterArea);
 
+        QLabel *parameterTitle = new QLabel("参数区", this);
+        parameterTitle->setAlignment(Qt::AlignCenter);
+        parameterTitle->setMinimumSize(QSize(4, 4));
+        layout->addWidget(parameterTitle, 4);
+        parameterAreaLayout->addWidget(parameterTitle, 1);
+
+        QDoubleValidator *validator = new QDoubleValidator(this);
+        validator->setNotation(QDoubleValidator::StandardNotation);
+        // 设置输入验证器，只允许输入整数或浮点数
+
+        QWidget *para_line_1 = new QWidget(this);
+        QHBoxLayout *para_line_box_1 = new QHBoxLayout(para_line_1);
+        QWidget *parameter_1 = new QWidget(this);
+        QVBoxLayout *para_box_1 = new QVBoxLayout(parameter_1);
+        QLabel *parameterLabel_1 = new QLabel("参数 1", this);
+        lineEdit_1 = new QLineEdit(this);
+        lineEdit_1->setPlaceholderText("Value 1");  // 设置默认值
+        int buttonHeight = lineEdit_1->sizeHint().height();
+        parameterLabel_1->setFixedHeight(buttonHeight);
+        lineEdit_1->setValidator(validator);
+        para_box_1->addWidget(parameterLabel_1, 1);
+        para_box_1->addWidget(lineEdit_1, 1);
+        connect(lineEdit_1, &QLineEdit::editingFinished, this, &ImageEditor::handlePara1EditingFinished);
+        QObject::connect(this, &ImageEditor::Para1Changed, drawingArea->scene, &CustomGraphicsScene::ReceivePara1ValueChanged);
+        para_line_box_1->addWidget(parameter_1, 1);
+
+        parameterTitle->setFixedHeight(buttonHeight);
+
+        QWidget *parameter_2 = new QWidget(this);
+        QVBoxLayout *para_box_2 = new QVBoxLayout(parameter_2);
+        QLabel *parameterLabel_2 = new QLabel("参数 2", this);
+        lineEdit_2 = new QLineEdit(this);
+        lineEdit_2->setPlaceholderText("Value 2");  // 设置默认值
+        parameterLabel_2->setFixedHeight(buttonHeight);
+        lineEdit_2->setValidator(validator);
+        para_box_2->addWidget(parameterLabel_2, 1);
+        para_box_2->addWidget(lineEdit_2, 1);
+        connect(lineEdit_2, &QLineEdit::editingFinished, this, &ImageEditor::handlePara2EditingFinished);
+        QObject::connect(this, &ImageEditor::Para2Changed, drawingArea->scene, &CustomGraphicsScene::ReceivePara2ValueChanged);
+        para_line_box_1->addWidget(parameter_2, 1);
+
+        QWidget *para_line_2 = new QWidget(this);
+        QHBoxLayout *para_line_box_2 = new QHBoxLayout(para_line_2);
+        QWidget *parameter_3 = new QWidget(this);
+        QVBoxLayout *para_box_3 = new QVBoxLayout(parameter_3);
+        QLabel *parameterLabel_3 = new QLabel("参数 3", this);
+        lineEdit_3 = new QLineEdit(this);
+        lineEdit_3->setPlaceholderText("Value 3");  // 设置默认值
+        parameterLabel_3->setFixedHeight(buttonHeight);
+        lineEdit_3->setValidator(validator);
+        para_box_3->addWidget(parameterLabel_3, 1);
+        para_box_3->addWidget(lineEdit_3, 1);
+        connect(lineEdit_3, &QLineEdit::editingFinished, this, &ImageEditor::handlePara3EditingFinished);
+        QObject::connect(this, &ImageEditor::Para3Changed, drawingArea->scene, &CustomGraphicsScene::ReceivePara3ValueChanged);
+        para_line_box_2->addWidget(parameter_3, 1);
+
+        QWidget *parameter_4 = new QWidget(this);
+        QVBoxLayout *para_box_4 = new QVBoxLayout(parameter_4);
+        QLabel *parameterLabel_4 = new QLabel("参数 4", this);
+        lineEdit_4 = new QLineEdit(this);
+        lineEdit_4->setPlaceholderText("Value 4");  // 设置默认值
+        parameterLabel_4->setFixedHeight(buttonHeight);
+        lineEdit_4->setValidator(validator);
+        para_box_4->addWidget(parameterLabel_4, 1);
+        para_box_4->addWidget(lineEdit_4, 1);
+        connect(lineEdit_4, &QLineEdit::editingFinished, this, &ImageEditor::handlePara4EditingFinished);
+        QObject::connect(this, &ImageEditor::Para4Changed, drawingArea->scene, &CustomGraphicsScene::ReceivePara4ValueChanged);
+        para_line_box_2->addWidget(parameter_4, 1);
+
+        parameterAreaLayout->addWidget(para_line_1, 1);
+        parameterAreaLayout->addWidget(para_line_2, 1);
+        layout->addWidget(parameterArea, 1);
+
+    QWidget *insertButton[3];
+    for(int i = 0; i < 3; i++)
+        insertButton[i] = new QWidget(this);
+    QHBoxLayout *insertButtonLayout[3];
+    for(int i = 0; i < 3; i++)
+        insertButtonLayout[i] = new QHBoxLayout(insertButton[i]);
 
     QPushButton *insertLineButton = new QPushButton("插入 直线", this);
+    insertButtonLayout[0]->addWidget(insertLineButton);
+    QPushButton *insertTextButton = new QPushButton("插入 文本", this);
+    insertButtonLayout[0]->addWidget(insertTextButton);
     QPushButton *insertRectButton = new QPushButton("插入 矩形", this);
+    insertButtonLayout[1]->addWidget(insertRectButton);
     QPushButton *insertCircleButton = new QPushButton("插入 圆", this);
+    insertButtonLayout[1]->addWidget(insertCircleButton);
+    QPushButton *insertFillRectButton = new QPushButton("插入 填充矩形", this);
+    insertButtonLayout[2]->addWidget(insertFillRectButton);
+    QPushButton *insertFillCircleButton = new QPushButton("插入 填充圆", this);
+    insertButtonLayout[2]->addWidget(insertFillCircleButton);
+
     //链接按钮槽和信号
     connect(insertCircleButton, &QPushButton::clicked, this, &ImageEditor::onAddCircleButtonClicked);
+    connect(insertFillCircleButton, &QPushButton::clicked, this, &ImageEditor::onAddFillCircleButtonClicked);
     connect(insertLineButton, &QPushButton::clicked, this, &ImageEditor::onAddLineButtonClicked);
     connect(insertRectButton, &QPushButton::clicked, this, &ImageEditor::onAddRectangleButtonClicked);
+    connect(insertFillRectButton, &QPushButton::clicked, this, &ImageEditor::onAddFillRectangleButtonClicked);
+    connect(insertTextButton, &QPushButton::clicked, this, &ImageEditor::onAddTextButtonClicked);
 
     connect(drawingArea->scene, &CustomGraphicsScene::circleAdded, this, &ImageEditor::handleCircleAdded);
 
-
-
-    QPushButton *insertEllipticButton = new QPushButton("插入 椭圆", this);
-    QPushButton *insertTextButton = new QPushButton("插入 文本", this);
-
-    QDoubleValidator *validator = new QDoubleValidator(this);
-    validator->setNotation(QDoubleValidator::StandardNotation);
-    // 设置输入验证器，只允许输入整数或浮点数
-
-    QWidget *parameter_1 = new QWidget(this);
-    QVBoxLayout *para_box_1 = new QVBoxLayout(parameter_1);
-    QLabel *parameterLabel_1 = new QLabel("参数 1", this);
-    lineEdit_1 = new QLineEdit(this);
-    lineEdit_1->setPlaceholderText("Value 1");  // 设置默认值
-    int buttonHeight = lineEdit_1->sizeHint().height();
-    parameterLabel_1->setFixedHeight(buttonHeight);
-    lineEdit_1->setValidator(validator);
-    para_box_1->addWidget(parameterLabel_1, 1);
-    para_box_1->addWidget(lineEdit_1, 1);
-    connect(lineEdit_1, &QLineEdit::editingFinished, this, &ImageEditor::handlePara1EditingFinished);
-    QObject::connect(this, &ImageEditor::Para1Changed, drawingArea->scene, &CustomGraphicsScene::ReceivePara1ValueChanged);
-
-    parameterTitle->setFixedHeight(buttonHeight);
-
-    QWidget *parameter_2 = new QWidget(this);
-    QVBoxLayout *para_box_2 = new QVBoxLayout(parameter_2);
-    QLabel *parameterLabel_2 = new QLabel("参数 2", this);
-    lineEdit_2 = new QLineEdit(this);
-    lineEdit_2->setPlaceholderText("Value 2");  // 设置默认值
-    parameterLabel_2->setFixedHeight(buttonHeight);
-    lineEdit_2->setValidator(validator);
-    para_box_2->addWidget(parameterLabel_2, 1);
-    para_box_2->addWidget(lineEdit_2, 1);
-    connect(lineEdit_2, &QLineEdit::editingFinished, this, &ImageEditor::handlePara2EditingFinished);
-    QObject::connect(this, &ImageEditor::Para2Changed, drawingArea->scene, &CustomGraphicsScene::ReceivePara2ValueChanged);
-
-    QWidget *parameter_3 = new QWidget(this);
-    QVBoxLayout *para_box_3 = new QVBoxLayout(parameter_3);
-    QLabel *parameterLabel_3 = new QLabel("参数 3", this);
-    lineEdit_3 = new QLineEdit(this);
-    lineEdit_3->setPlaceholderText("Value 3");  // 设置默认值
-    parameterLabel_3->setFixedHeight(buttonHeight);
-    lineEdit_3->setValidator(validator);
-    para_box_3->addWidget(parameterLabel_3, 1);
-    para_box_3->addWidget(lineEdit_3, 1);
-    connect(lineEdit_3, &QLineEdit::editingFinished, this, &ImageEditor::handlePara3EditingFinished);
-    QObject::connect(this, &ImageEditor::Para3Changed, drawingArea->scene, &CustomGraphicsScene::ReceivePara3ValueChanged);
-
-    QWidget *parameter_4 = new QWidget(this);
-    QVBoxLayout *para_box_4 = new QVBoxLayout(parameter_4);
-    QLabel *parameterLabel_4 = new QLabel("参数 4", this);
-    lineEdit_4 = new QLineEdit(this);
-    lineEdit_4->setPlaceholderText("Value 4");  // 设置默认值
-    parameterLabel_4->setFixedHeight(buttonHeight);
-    lineEdit_4->setValidator(validator);
-    para_box_4->addWidget(parameterLabel_4, 1);
-    para_box_4->addWidget(lineEdit_4, 1);
-    connect(lineEdit_4, &QLineEdit::editingFinished, this, &ImageEditor::handlePara4EditingFinished);
-    QObject::connect(this, &ImageEditor::Para4Changed, drawingArea->scene, &CustomGraphicsScene::ReceivePara4ValueChanged);
-
     QPushButton *closeButton = new QPushButton("关闭", this);
-    layout->addWidget(parameter_1, 1);
-    layout->addWidget(parameter_2, 1);
-    layout->addWidget(parameter_3, 1);
-    layout->addWidget(parameter_4, 1);
+
 
     QLabel *ColorTitle = new QLabel("调色区", this);
     ColorTitle->setAlignment(Qt::AlignCenter);
@@ -236,23 +325,69 @@ ImageEditor::ImageEditor(QWidget *parent) : QWidget(parent) {
     QLabel *StyleTitle = new QLabel("样式区", this);
     StyleTitle->setAlignment(Qt::AlignCenter);
     StyleTitle->setFixedHeight(2 * buttonHeight);
-    QPushButton *FontButton = new QPushButton("设置字体", this);
-    QPushButton *BrushButton = new QPushButton("设置笔刷", this);
+    fontComboBox = new QComboBox(this);
+    QFontDatabase fontDatabase;
+    fontComboBox->addItems(fontDatabase.families());
+
+    QWidget * brushBox = new QWidget(this);
+    QVBoxLayout * brushBoxLayout = new QVBoxLayout(brushBox);
+    QSlider* brushSlider(new QSlider(Qt::Horizontal, this));
+    styleLabel = new QLabel("设置笔刷大小: 4", this);
+    brushSlider->setMinimum(1);
+    brushSlider->setMaximum(16);
+    brushSlider->setValue(4);
+    brushSlider->setTickPosition(QSlider::TicksBelow);
+    brushSlider->setTickInterval(1);
+    brushBoxLayout->addWidget(styleLabel, 1);
+    brushBoxLayout->addWidget(brushSlider, 1);
+    LineColor.setWidth(4);
+    drawingArea->scene->LineColor.setWidth(4);
+
+    fontSizeComboBox = new QComboBox(this);
+    for (int i = 8; i <= 48; i += 2) {
+        fontSizeComboBox->addItem(QString::number(i));
+    }
+    fontSizeComboBox->setCurrentText("12");
+
+    //setCentralWidget(centralWidget);
+
+    fontLabel = new QLabel("设置文本字体: 微软雅黑", this);
+    QString defaultFont = "微软雅黑"; // 预设的字体名称
+    int defaultIndex = fontComboBox->findText(defaultFont);
+    if (defaultIndex != -1) {
+        fontComboBox->setCurrentIndex(defaultIndex);
+        QFont font(defaultFont);
+        fontLabel->setFont(font); // 设置 label 的初始字体
+    }
+    fontLabel->setFont(QFont("微软雅黑"));
+
+    QWidget * FontBox = new QWidget(this);
+    QVBoxLayout * fontBoxLayout = new QVBoxLayout(FontBox);
+    QWidget * FontComboBox = new QWidget(this);
+    QHBoxLayout * fontComboBoxLayout = new QHBoxLayout(FontComboBox);
+    fontComboBox->setMinimumSize(QSize(16, 16));
+    fontComboBoxLayout->addWidget(fontComboBox, 3);
+    fontComboBoxLayout->addWidget(fontSizeComboBox, 1);
+    fontBoxLayout->addWidget(fontLabel, 1);
+    fontBoxLayout->addWidget(FontComboBox, 1);
+
+    connect(brushSlider, &QSlider::valueChanged, this, &ImageEditor::onSliderValueChanged);
+    connect(fontComboBox, &QComboBox::currentTextChanged, this, &ImageEditor::onFontChanged);
+    connect(fontSizeComboBox, &QComboBox::currentTextChanged, this, &ImageEditor::onFontSizeChanged);
 
     layout->addWidget(StyleTitle, 1);
-    layout->addWidget(FontButton, 1);
-    layout->addWidget(BrushButton, 1);
+    layout->addWidget(brushBox, 1);
+    layout->addWidget(FontBox, 1);
 
     QLabel *ButtonsTitle = new QLabel("插入区", this);
     ButtonsTitle->setFixedHeight(buttonHeight);
     ButtonsTitle->setAlignment(Qt::AlignCenter);
     buttonsLayout->addWidget(ButtonsTitle, 4);
 
-    buttonsLayout->addWidget(insertLineButton, 1);
-    buttonsLayout->addWidget(insertRectButton, 1);
-    buttonsLayout->addWidget(insertCircleButton, 1);
-    buttonsLayout->addWidget(insertEllipticButton, 1);
-    buttonsLayout->addWidget(insertTextButton, 1);
+    buttonsLayout->addWidget(insertButton[0], 1);
+    buttonsLayout->addWidget(insertButton[1], 1);
+    buttonsLayout->addWidget(insertButton[2], 1);
+    //buttonsLayout->addWidget(insertTextButton, 1);
     layout->addWidget(Buttons, 6);
 
     layout->addWidget(closeButton, 3);
@@ -263,8 +398,8 @@ ImageEditor::ImageEditor(QWidget *parent) : QWidget(parent) {
     painter.setPen(Qt::blue);
     drawingArea->drawShapes(painter);
 
+    connect(closeButton, &QPushButton::clicked, this, &ImageEditor::onGenerateCodeButtonClicked);
     connect(closeButton, &QPushButton::clicked, this, &ImageEditor::onSendData);
-
 }
 
 void ImageEditor::receiveColorData(const QString &data) {
@@ -298,18 +433,21 @@ void ImageEditor::receiveColorData(const QString &data) {
 
         if (colors.size() > 1) {
             QList<int> lineColor = colors.at(1);
-            LineColor = QPen(QColor(lineColor.at(0), lineColor.at(1), lineColor.at(2)));
+            //LineColor = QPen(QColor(lineColor.at(0), lineColor.at(1), lineColor.at(2)));
+            LineColor.setColor(QColor(lineColor.at(0), lineColor.at(1), lineColor.at(2)));
             drawingArea->scene->LineColor = LineColor;
         }
 
         if (colors.size() > 2) {
             QList<int> fillColor = colors.at(2);
-            FillColor = QPen(QColor(fillColor.at(0), fillColor.at(1), fillColor.at(2)));
+            FillColor.setColor(QColor(fillColor.at(0), fillColor.at(1), fillColor.at(2)));
+            FillCOLOR = QColor(fillColor.at(0), fillColor.at(1), fillColor.at(2));
         }
     }
 }
 
 void ImageEditor::onSendData() {
+    ToHandle = generator.getCode();
     emit sendData(ToHandle); // 发射信号将数据传回A窗口
     this->close(); // 关闭B窗口
 }
@@ -351,3 +489,28 @@ void ImageEditor::handlePara4EditingFinished()
         emit Para4Changed(value);
 }
 
+void ImageEditor::onSliderValueChanged(int value)
+{
+    styleLabel->setText(QString("设置笔刷大小: %1").arg(value));
+    LineColor.setWidth(value);
+    drawingArea->scene->LineColor.setWidth(value);
+}
+
+void ImageEditor::onFontChanged(const QString &fontName)
+{
+    QFont font(fontName);
+    fontLabel->setText(QString("设置文本字体: %1").arg(fontName));
+    font.setPixelSize(fontSizeComboBox->currentText().toInt());
+    fontLabel->setFont(font);
+    textFont = font;
+    drawingArea->scene->text->setFont(textFont);
+    //label->setFont(font);
+}
+
+void ImageEditor::onFontSizeChanged(const QString &fontSize)
+{
+    QFont font(fontComboBox->currentText(), fontSize.toInt());
+    //textFont.setPixelSize(fontSize.toInt());
+    textFont = font;
+    drawingArea->scene->text->setFont(textFont);
+}

--- a/imageEditor.h
+++ b/imageEditor.h
@@ -20,6 +20,7 @@ private:
     bool isAddingText;
     bool isAddingLine;
     bool isAddingRectangle;
+    bool usingFill;
 
     EasyXCodeGenerator generator;
     QLineEdit *lineEdit_1;
@@ -27,9 +28,14 @@ private:
     QLineEdit *lineEdit_3;
     QLineEdit *lineEdit_4;
     QPen LineColor;
+    QColor FillCOLOR;
     QPen FillColor;
+    QFont textFont;
     QPen BackColor;
-
+    QLabel *styleLabel;
+    QLabel *fontLabel;
+    QComboBox *fontComboBox;
+    QComboBox* fontSizeComboBox;
 
 signals:
     void sendData(const QString &data);
@@ -43,21 +49,29 @@ private slots:
     void onShapeSelected(const QString &shapeInfo);
 
     void onAddCircleButtonClicked();
+    void onAddFillCircleButtonClicked();
     void onAddLineButtonClicked();
     void onGenerateCodeButtonClicked();
     void onAddRectangleButtonClicked();
+    void onAddFillRectangleButtonClicked();
+    void onAddTextButtonClicked();
 
     void receiveColorData(const QString &data);
     void onSendData();
     void handleCircleAdded(QPointF center,qreal r);
     void handleDrawingCircleFinished(const QString& message);
     void handleDrawingLineFinished(const QString& message);
+    void handleDrawingRectFinished(const QString& message);
 
     void updateLineEdit(const QString& message);
     void handlePara1EditingFinished();
     void handlePara2EditingFinished();
     void handlePara3EditingFinished();
     void handlePara4EditingFinished();
+
+    void onSliderValueChanged(int value);
+    void onFontChanged(const QString &fontName);
+    void onFontSizeChanged(const QString &fontSize);
 };
 
 #endif // IMAGEEDITOR_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -42,6 +42,7 @@ private slots:
 public slots:
     void DrawSomeThing(const QString& text);
     void receiveData(const QString &data);
+    void removeSolveFunction(QTextEdit *document);
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
新增代码读取，现在可以读取除文本外所有代码
新增代码自清理，避免重复绘制
新增了调色盘中“获取各类颜色”按钮的功能，按下此按钮将直接读取现有颜色，可用于拷贝该颜色到其他颜色
修复了调色盘传入颜色必须强制设置四个颜色的问题
不完全修复了矩形绘制时必须先左上后右下的问题
将代码生成强制限定于solve函数（避免代码插入错误）